### PR TITLE
feat: add support for arm64 architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.extract_version.outputs.version }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
# Description

Currently images are only being built for `linux/amd64` platforms. This means that when trying to leverage the image from an Apple M1, or other machines that use ARM64, the build will fail.

This pull requests ensures the build is done for both platforms.

## Example error

```sh
❯ docker build https://raw.githubusercontent.com/railwayapp-templates/timescale-postgis-ssl/refs/heads/main/Dockerfile.pg15-ts2.12
[+] Building 1.3s (3/3) FINISHED                                                                                                                       docker:desktop-linux
 => [internal] load remote build context                                                                                                                               0.1s
 => ERROR [internal] load metadata for docker.io/timescale/timescaledb-ha:pg15-ts2.12                                                                                  1.2s
 => [auth] timescale/timescaledb-ha:pull token for registry-1.docker.io                                                                                                0.0s
------
 > [internal] load metadata for docker.io/timescale/timescaledb-ha:pg15-ts2.12:
------
context:1
--------------------
   1 | >>> FROM timescale/timescaledb-ha:pg15-ts2.12
   2 |     
   3 |     # Switch to root user for apt operations
--------------------
ERROR: failed to solve: timescale/timescaledb-ha:pg15-ts2.12: failed to resolve source metadata for docker.io/timescale/timescaledb-ha:pg15-ts2.12: no match for platform in manifest: not found

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/19qlys1q8161oezlj48y52g2z
```